### PR TITLE
Bonds looping

### DIFF
--- a/domain_generation/add_MPD.in
+++ b/domain_generation/add_MPD.in
@@ -1,19 +1,20 @@
-# Delete TMC
-delete_atoms group UNXLINKED_TMC
+# Delete MPD
+delete_atoms group UNXLINKED_MPD
 
 # Refresh - just in case
 group chlorine delete
 group XLINKED_ATOMS delete
 group UNXLINKED_ATOMS delete
 group UNXLINKED_TMC delete
+group UNXLINKED_MPD delete
 
 
-# Add in new TMC molecules 
-label tmc_pack_loop_2
+# Add in new MPD molecules 
+label MPD_pack_loop
 variable pp loop 1000
-variable TMC_mol_count_to_add equal (${atom_count}-$(atoms))/18
-print "TMC molecules needed to be added ${TMC_mol_count_to_add} Loop ${pp}"
-create_atoms 0 box subset ${TMC_mol_count_to_add} $(5221*v_pp*v_rand) mol TMCmol 325132
+variable MPD_mol_count_to_add equal (${atom_count}-$(atoms))/16
+print "MPD molecules needed to be added ${MPD_mol_count_to_add} Loop ${pp}"
+create_atoms 0 box subset ${MPD_mol_count_to_add} $(5221*v_pp*v_rand) mol MPDmol 325132
 
 group chlorine type 18
 group XLINKED_ATOMS variable atom_charge_xlinked
@@ -21,18 +22,18 @@ group XLINKED_ATOMS include molecule
 group UNXLINKED_ATOMS subtract all XLINKED_ATOMS
 group UNXLINKED_TMC intersect UNXLINKED_ATOMS chlorine
 group UNXLINKED_TMC include molecule
+group UNXLINKED_MPD subtract UNXLINKED_ATOMS UNXLINKED_TMC 
 
-
-print "Number of atoms in TMCs group: $(count(UNXLINKED_TMC))"
-delete_atoms overlap 1.0 UNXLINKED_TMC all mol yes
+print "Number of atoms in MPDs group: $(count(UNXLINKED_MPD))"
+delete_atoms overlap 1.0 UNXLINKED_MPD all mol yes
 fix 1 all nve
 run 0
 unfix 1
-if "$(atoms) == ${atom_count}" then "jump SELF tmc_pack_break_2"
+if "$(atoms) == ${atom_count}" then "jump SELF MPD_pack_break"
 next pp
-jump SELF tmc_pack_loop_2
+jump SELF MPD_pack_loop
 
-label tmc_pack_break_2
+label MPD_pack_break
 variable pp delete
 reset_atoms id
 

--- a/domain_generation/add_TMC.in
+++ b/domain_generation/add_TMC.in
@@ -1,0 +1,52 @@
+# Delete TMC
+delete_atoms group UNXLINKED_TMC
+
+# Refresh - just in case
+group chlorine delete
+group XLINKED_ATOMS delete
+group UNXLINKED_ATOMS delete
+group UNXLINKED_TMC delete
+
+
+# Add in new TMC molecules 
+label tmc_pack_loop_2
+variable pp loop 1000
+variable TMC_mol_count_to_add equal (${atom_count}-$(atoms))/18
+print "TMC molecules needed to be added ${TMC_mol_count_to_add} Loop ${pp}"
+create_atoms 0 box subset ${TMC_mol_count_to_add} $(5221*v_pp*v_rand) mol TMCmol 325132
+
+group chlorine type 18
+group XLINKED_ATOMS variable atom_charge_xlinked
+group XLINKED_ATOMS include molecule
+group UNXLINKED_ATOMS subtract all XLINKED_ATOMS
+group UNXLINKED_TMC intersect UNXLINKED_ATOMS chlorine
+group UNXLINKED_TMC include molecule
+
+
+print "Number of atoms in TMCs group: $(count(UNXLINKED_TMC))"
+delete_atoms overlap 1.0 UNXLINKED_TMC all mol yes
+fix 1 all nve
+run 0
+unfix 1
+if "$(atoms) == ${atom_count}" then "jump SELF tmc_pack_break_2"
+next pp
+jump SELF tmc_pack_loop_2
+
+label tmc_pack_break_2
+reset_atoms id
+
+# Minimize after add TMC Molecules 
+dielectric       1.0
+neighbor         2.0 bin
+neigh_modify     delay 0 every 1 check yes
+timestep         10.0
+run_style        verlet
+# Minimization Step
+min_style        sd
+minimize         1.0e-5 1.0e-5 10000 100000
+min_style        cg
+min_modify       line quadratic
+minimize         1.0e-8 1.0e-8 10000 100000
+
+# Reset the timestep
+timestep 1.0

--- a/domain_generation/delete_add_TMC.in
+++ b/domain_generation/delete_add_TMC.in
@@ -12,21 +12,30 @@ group XLINKED_ATOMS include molecule
 group UNXLINKED_ATOMS subtract all XLINKED_ATOMS
 group UNXLINKED_TMC intersect UNXLINKED_ATOMS chlorine
 group UNXLINKED_TMC include molecule
+group UNXLINKED_MPD subtract UNXLINKED_ATOMS UNXLINKED_TMC 
  
 variable count_UNXLINKED_TMC equal count(UNXLINKED_TMC)/18
 
 if "${count_UNXLINKED_TMC} > 0" then &
     "include ../../domain_generation/add_TMC.in"
 
+variable count_UNXLINKED_MPD equal count(UNXLINKED_MPD)/16
+
+if "${count_UNXLINKED_MPD} > 0" then &
+    "include ../../domain_generation/add_MPD.in"
+
 
 variable atom_count delete
 variable atom_charge_xlinked delete
 variable count_UNXLINKED_TMC delete
 variable TMC_mol_count_to_add delete
+variable count_UNXLINKED_MPD delete
+variable MPD_mol_count_to_add delete
 variable pp delete
 
 group chlorine delete
 group XLINKED_ATOMS delete
 group UNXLINKED_ATOMS delete
 group UNXLINKED_TMC delete
+group UNXLINKED_MPD delete
  

--- a/domain_generation/delete_add_TMC.in
+++ b/domain_generation/delete_add_TMC.in
@@ -1,0 +1,32 @@
+#  Identify un-bonded monomers based on charge 
+label delete_unxlinked
+
+# Keep exact atom count
+variable atom_count equal $(atoms)
+
+variable atom_charge_xlinked atom q==-0.3983750
+
+group chlorine type 18
+group XLINKED_ATOMS variable atom_charge_xlinked
+group XLINKED_ATOMS include molecule
+group UNXLINKED_ATOMS subtract all XLINKED_ATOMS
+group UNXLINKED_TMC intersect UNXLINKED_ATOMS chlorine
+group UNXLINKED_TMC include molecule
+ 
+variable count_UNXLINKED_TMC equal count(UNXLINKED_TMC)/18
+
+if "${count_UNXLINKED_TMC} > 0" then &
+    "include ../../domain_generation/add_TMC.in"
+
+
+variable atom_count delete
+variable atom_charge_xlinked delete
+variable count_UNXLINKED_TMC delete
+variable TMC_mol_count_to_add delete
+variable pp delete
+
+group chlorine delete
+group XLINKED_ATOMS delete
+group UNXLINKED_ATOMS delete
+group UNXLINKED_TMC delete
+ 

--- a/domain_generation/rec_polymerize_1_of_2.in
+++ b/domain_generation/rec_polymerize_1_of_2.in
@@ -93,20 +93,33 @@ variable MAX_BONDS equal count(NUM_AMIDE)
 print "MAX_BONDS = ${MAX_BONDS}"
 variable TARGET_BONDS equal (${MAX_BONDS}*${xlink}) #target crosslinking degree
 
+
+# variable sum equal 0
+# variable inc equal 0
+# variable sum equal f_store+v_inc
+variable PAbonds_made equal 0
+variable sum equal f_count_bonds+v_PAbonds_made
+# variable sum equal f_count_bonds+f_PArxn[1]
+label bondcounting
+fix count_bonds all ave/time 1 1 1 v_sum
+
 label SETRXN
+print "testing testing testing ${PAbonds_made}" 
 fix PArxn all bond/react stabilization yes statted_grp .03 &
   react rxn1 all ${BONDFREQ} 0.0 5.0 mol1 mol2 ../../domain_in/MPDTMC_rxnmap.in
 
 thermo 100
 thermo_style custom step temp press density f_PArxn[1]
 
-variable PAbonds_made equal f_PArxn[1]
+# variable PAbonds_made equal f_PArxn[1]+v_all_PA_bonds
+# variable sum equal f_count_bonds+f_PArxn[1]
 
 restart 100 restarts_polym/polym.restart
 label loop
 variable a loop 375
 if "${a} > 3" then "restart 10000 restarts_polym/polym.restart" 
-print "==================================Current bonds formed = ${PAbonds_made} Minimum bonds desired = ${TARGET_BONDS}======================================="
+# print "==================================Current bonds formed = ${PAbonds_made} Minimum bonds desired = ${TARGET_BONDS}======================================="
+print "==================================Current bonds formed = ${sum} Minimum bonds desired = ${TARGET_BONDS}======================================="
 print "==================================NVT PA POLYMERIZATION RUN: 300 C==============================="
 velocity all create 300.0 $(66644*v_a*v_rand)
 fix 1 statted_grp_REACT nvt temp 300 300 $(100.*dt)
@@ -120,11 +133,24 @@ run 1000
 unfix 1
 unfix 4
 reset_atoms id
-if "${PAbonds_made} >= ${TARGET_BONDS}" then "jump SELF break"
-variable b equal ${a}
+# if "${PAbonds_made} >= ${TARGET_BONDS}" then "jump SELF break"
+# if "${f_count_bonds} >= ${TARGET_BONDS}" then "jump SELF break"
+print "${a}"
 next a
 
-jump SELF loop
+variable PAbonds_made equal f_PArxn[1]
+#variable all_PA_bonds equal v_PAbonds_made
+if "${a} >= 1 && ${a} != 375" then "jump SELF SETRXN" elif "${a} == 375" "jump SELF break" else "jump SELF loop"
+
+
+
+
+
+
+
+
+
+
 
 label break
 print "==================================FORMING BONDS COMPLETE DONE: Total bonds formed = ${PAbonds_made}============"

--- a/domain_generation/rec_polymerize_1_of_2_bond_distance.in
+++ b/domain_generation/rec_polymerize_1_of_2_bond_distance.in
@@ -113,15 +113,14 @@ variable TARGET_BONDS equal (${MAX_BONDS}*${xlink}) #target crosslinking degree
 
 
 # Set up for tracking bond count
-# outer_bound_count holds the count when we change methods. 
-# inner_bound_count tracks the bond count for a specific method
+# outer_bound_count holds the count when we change approaches and need to delete (unfix) the reaction. 
+# inner_bound_count tracks the bond count for a specific method/ instance of a reaction
 variable outer_bond_count equal 0
 variable current_bond_count equal 0
-fix bond_tracking all print 1 "Bonds Approach Count Iteration Count " file iterations_bond.out title "" screen no
-
+fix bond_tracking all print 1 "Bonds Approach Count Iteration Count " file iterations_bond_distance.out title "" screen no
 
 # Set the maximum number of approaches we are going to use
-variable num_approaches equal 5
+variable num_approaches equal 5 
 variable approach_attempt loop $(v_num_approaches)
 
 # Label for outer loop. Here we can modify the approach 
@@ -132,14 +131,17 @@ label update_approach
 variable max_bond_distance equal 5.0
 variable bond_frequency equal 50
 
+if "${approach_attempt} > 1" then &
+  "variable max_bond_distance equal $(v_max_bond_distance + 0.25*v_approach_attempt)"
+
 # Define reaction 
 fix PArxn all bond/react stabilization yes statted_grp .03 &
   react rxn1 all ${bond_frequency} 0.0 ${max_bond_distance} mol1 mol2 ../../domain_in/MPDTMC_rxnmap.in
 
 # Set to track bond count with this approach 
 variable inner_bond_count equal f_PArxn[1]
-thermo 1000
-thermo_style custom step temp press density
+thermo 0
+thermo_style custom step temp press density v_current_bond_count
 
 # Set up inner loop 
 label keep_reacting
@@ -154,7 +156,7 @@ velocity all create 300.0 $(66644*v_inner_loop*v_rand)
 
 
 # Track the bond count and other information in file 
-fix bond_tracking all print 2000 "Bonds ${current_bond_count} No Approach Count ${approach_attempt} Iteration Count ${inner_loop}" append iterations_bond.out title "" screen no
+fix bond_tracking all print 2000 "Bonds ${current_bond_count} Approach Count ${approach_attempt} Iteration Count ${inner_loop} Bond Distance ${max_bond_distance}" append iterations_bond_distance.out title "" screen no
 
 
 # Reacting and unreacting 
@@ -198,11 +200,11 @@ elif "${num_approaches} == ${approach_attempt}" &
   "jump SELF end_bond_forming" &
 else &
   "next inner_loop" &
-  "jump SELF keep_reacting"
+ "jump SELF keep_reacting"
 
 label end_bond_forming
 print "==================================FORMING BONDS COMPLETE DONE: Total bonds formed = ${current_bond_count}============"
-print "${current_bond_count}" file PA_bonds.in screen no
+print "${current_bond_count}" file PA_bonds.in
 variable  PAbonds_final equal ${current_bond_count}
 unfix PArxn
 

--- a/domain_generation/rec_polymerize_1_of_2_bond_distance.in
+++ b/domain_generation/rec_polymerize_1_of_2_bond_distance.in
@@ -132,7 +132,7 @@ variable max_bond_distance equal 5.0
 variable bond_frequency equal 50
 
 if "${approach_attempt} > 1" then &
-  "variable max_bond_distance equal $(v_max_bond_distance + 0.25*v_approach_attempt)"
+  "variable max_bond_distance equal $(v_max_bond_distance + 1*v_approach_attempt)"
 
 # Define reaction 
 fix PArxn all bond/react stabilization yes statted_grp .03 &

--- a/domain_generation/rec_polymerize_1_of_2_reinsertion.in
+++ b/domain_generation/rec_polymerize_1_of_2_reinsertion.in
@@ -117,11 +117,11 @@ variable TARGET_BONDS equal (${MAX_BONDS}*${xlink}) #target crosslinking degree
 # inner_bound_count tracks the bond count for a specific method
 variable outer_bond_count equal 0
 variable current_bond_count equal 0
-fix bond_tracking all print 1 "Bonds Approach Count Iteration Count " file iterations_bond.out title "" screen no
+fix bond_tracking all print 1 "Bonds Approach Count Iteration Count " file iterations_bond_reinsertion.out title "" screen no
 
 
 # Set the maximum number of approaches we are going to use
-variable num_approaches equal 5
+variable num_approaches equal 5 
 variable approach_attempt loop $(v_num_approaches)
 
 # Label for outer loop. Here we can modify the approach 
@@ -132,14 +132,17 @@ label update_approach
 variable max_bond_distance equal 5.0
 variable bond_frequency equal 50
 
+if "${approach_attempt} > 1" then &
+  "include ../../domain_generation/delete_add_TMC.in"
+
 # Define reaction 
 fix PArxn all bond/react stabilization yes statted_grp .03 &
   react rxn1 all ${bond_frequency} 0.0 ${max_bond_distance} mol1 mol2 ../../domain_in/MPDTMC_rxnmap.in
 
 # Set to track bond count with this approach 
 variable inner_bond_count equal f_PArxn[1]
-thermo 1000
-thermo_style custom step temp press density
+thermo 0
+thermo_style custom step temp press density v_current_bond_count
 
 # Set up inner loop 
 label keep_reacting
@@ -154,7 +157,7 @@ velocity all create 300.0 $(66644*v_inner_loop*v_rand)
 
 
 # Track the bond count and other information in file 
-fix bond_tracking all print 2000 "Bonds ${current_bond_count} No Approach Count ${approach_attempt} Iteration Count ${inner_loop}" append iterations_bond.out title "" screen no
+fix bond_tracking all print 2000 "Bonds ${current_bond_count} Approach Count ${approach_attempt} Iteration Count ${inner_loop}" append iterations_bond_reinsertion.out title "" screen no
 
 
 # Reacting and unreacting 
@@ -198,11 +201,11 @@ elif "${num_approaches} == ${approach_attempt}" &
   "jump SELF end_bond_forming" &
 else &
   "next inner_loop" &
-  "jump SELF keep_reacting"
+ "jump SELF keep_reacting"
 
 label end_bond_forming
 print "==================================FORMING BONDS COMPLETE DONE: Total bonds formed = ${current_bond_count}============"
-print "${current_bond_count}" file PA_bonds.in screen no
+print "${current_bond_count}" file PA_bonds.in
 variable  PAbonds_final equal ${current_bond_count}
 unfix PArxn
 

--- a/domain_generation/rec_polymerize_1_of_2_reinsertion.in
+++ b/domain_generation/rec_polymerize_1_of_2_reinsertion.in
@@ -24,6 +24,9 @@ improper_style   harmonic
 special_bonds    charmm
 
 
+variable restart_value equal 40000
+
+
 # Set up domain size
 variable BOXSIZE_X equal 90*${mult}^(1/3)
 variable BOXSIZE_Y equal 90*${mult}^(1/3)
@@ -121,7 +124,7 @@ fix bond_tracking all print 1 "Bonds Approach Count Iteration Count " file itera
 
 
 # Set the maximum number of approaches we are going to use
-variable num_approaches equal 5 
+variable num_approaches equal 50
 variable approach_attempt loop $(v_num_approaches)
 
 # Label for outer loop. Here we can modify the approach 
@@ -144,13 +147,13 @@ variable inner_bond_count equal f_PArxn[1]
 thermo 0
 thermo_style custom step temp press density v_current_bond_count
 
-# Set up inner loop 
+# Set up inner loop s
 label keep_reacting
-variable loop_count equal 10
+variable loop_count equal 40
 variable inner_loop loop $(v_loop_count)
 
 
-# if "${inner_loop} > 3" then "restart 10000 restarts_polym/polym.restart" 
+restart ${restart_value} restarts_polym/polym.restart
 print "==================================Current bonds formed = ${current_bond_count} Minimum bonds desired = ${TARGET_BONDS}======================================="
 print "==================================NVT PA POLYMERIZATION RUN: 300 C==============================="
 velocity all create 300.0 $(66644*v_inner_loop*v_rand)


### PR DESCRIPTION
This PR allows for accelerating the initial polymerization packing by either increasing the bond distance or deleting the non-reacted TMC monomers and re-introducing them at a different location within the domain. Both of these approaches occur at fixed intervals.

The new input scripts are `rec_polymerize_1_of_2_bond_distance.in` and `rec_polymerize_1_of_2_reinsertion.in`. These scripts write to files called `iterations_bond_*` that contains the bond count and iteration number to help determine if these approaches actually speed anything up. 

If they do speed things up, we should examine the pore size distributions (at a minimum) to see if we observe any changes. 
